### PR TITLE
feat: add RFC 7807 error response support and OpenAPI null field injection

### DIFF
--- a/custom_enum/enums.py
+++ b/custom_enum/enums.py
@@ -19,6 +19,8 @@ class BaseExceptionCode(Enum):
     - error_code: Unique identifier for the error.
     - message: User-friendly description of the error.
     - description: Optional detailed description for additional context.
+    - rfc7807_type: Optional A URI reference for the error type, a human-readable document or spec for RFC 7807 format
+    - rfc7807_instance: Optional A URI that identifies the specific occurrence of the error for RFC 7807 format
     """
 
     @property
@@ -33,6 +35,13 @@ class BaseExceptionCode(Enum):
     def description(self):
         return self.value[2] if len(self.value) > 2 else ""
 
+    @property
+    def rfc7807_type(self):
+        return self.value[3] if len(self.value) > 3 else ""
+
+    @property
+    def rfc7807_instance(self):
+        return self.value[4] if len(self.value) > 4 else ""
 
 class ExceptionCode(BaseExceptionCode):
     """

--- a/enums/response_scheme.py
+++ b/enums/response_scheme.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class ResponseFormat(str, Enum):
+    RESPONSE_MODEL = "response_model"
+    RESPONSE_DICTIONARY = "response_dict"
+    RFC7807 = "rfc7807"

--- a/examples/fastapi_rfc7807_usage.py
+++ b/examples/fastapi_rfc7807_usage.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, Path
+from pydantic import BaseModel, Field
+from api_exception import (
+    APIException,
+    BaseExceptionCode,
+    register_exception_handlers,
+    APIResponse,
+)
+from enums.response_scheme import ResponseFormat
+
+app = FastAPI()
+register_exception_handlers(app,response_format=ResponseFormat.RFC7807)
+
+
+'''
+Custom Exception Class that you can define in your code to make the backend responses look more standardized.
+Just extend the `BaseExceptionCode` and use it. 
+'''
+class CustomExceptionCode(BaseExceptionCode):
+    INVALID_API_KEY = ("API-401", "Invalid API key.", "Provide a valid API key.","https://example.com/errors/unauthorized","/account/info")
+    PERMISSION_DENIED = ("PERM-403", "Permission denied.", "Access to this resource is forbidden.", "https://example.com/errors/forbidden", "/admin/panel")
+    VALIDATION_ERROR = ("VAL-422", "Validation Error", "Input validation failed.", "https://example.com/errors/unprocessable-entity", "/users/create")
+
+
+@app.get(
+    "/rfc7807",
+    responses=APIResponse.rfc7807(
+        (401, CustomExceptionCode.INVALID_API_KEY, "https://example.com/errors/unauthorized", "/account/info"),
+        (403, CustomExceptionCode.PERMISSION_DENIED, "https://example.com/errors/forbidden", "/admin/panel"),
+        (422, CustomExceptionCode.VALIDATION_ERROR, "https://example.com/errors/unprocessable-entity", "/users/create")
+    ),
+)
+async def rfc7807_example():
+    raise APIException(
+        error_code=CustomExceptionCode.PERMISSION_DENIED,
+        http_status_code=403
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/fastapi_usage.py
+++ b/examples/fastapi_usage.py
@@ -22,7 +22,7 @@ class CustomExceptionCode(BaseExceptionCode):
     INVALID_API_KEY = ("API-401", "Invalid API key.", "Provide a valid API key.")
     PERMISSION_DENIED = ("PERM-403", "Permission denied.", "Access to this resource is forbidden.")
     VALIDATION_ERROR = ("VAL-422", "Validation Error", "Input validation failed.")
-    TYPE_ERROR = ("TYPE-400", "Type error.", "A type mismatch occurred in the request.")  # <- EKLENDİ
+    TYPE_ERROR = ("TYPE-400", "Type error.", "A type mismatch occurred in the request.")
 
 
 class UserResponse(BaseModel):

--- a/schemas/rfc7807_model.py
+++ b/schemas/rfc7807_model.py
@@ -1,0 +1,63 @@
+from typing import Generic, TypeVar, Optional
+from pydantic import BaseModel, Field
+
+# Generic type for response data
+DataT = TypeVar('DataT')
+
+
+class RFC7807ResponseModel(BaseModel, Generic[DataT]):
+    """
+    Pydantic model compliant with RFC 7807 (Problem Details for HTTP APIs).
+
+    This model standardizes error responses according to the RFC 7807 spec.
+    It provides a consistent and interoperable format that includes all mandatory
+    and optional fields specified by the standard.
+
+    Attributes:
+    -----------
+    - type: Optional[`str`]
+        A URI reference (can be a URL or a URN) for the type of error. Can point to documentation or specification.
+    - title: `str`
+        A short, human-readable summary of the error.
+    - status: `int`
+        The HTTP status code applicable to this error.
+    - detail: Optional[`str`]
+        A human-readable explanation specific to this occurrence of the problem.
+    - instance: Optional[`str`]
+        A URI reference that identifies the specific occurrence of the problem, e.g., the request path.
+
+    Optional Extensions:
+    --------------------
+    - error_code: Optional[`str`]
+        A custom internal error code for client-side parsing or analytics.
+    """
+
+    type: Optional[str] = Field(
+        default=None,
+        description="A URI reference (can be a URL or a URN) for the error type. Should point to a human-readable document or spec.",
+        examples=["https://example.com/errors/invalid-input"]
+    )
+    title: str = Field(
+        ...,
+        description="A short, human-readable summary of the problem type.",
+        examples=["Invalid Request", "Authentication Failed", "Permission Denied"]
+    )
+    status: int = Field(
+        ...,
+        description="The HTTP status code associated with this error.",
+        examples=[400, 401, 403, 404, 422, 500]
+    )
+    detail: Optional[str] = Field(
+        default=None,
+        description="A human-readable explanation of the problem.",
+        examples=[
+            "The email field must be a valid email address.",
+            "Your API key is missing or invalid.",
+            "You do not have permission to access this resource."
+        ]
+    )
+    instance: Optional[str] = Field(
+        default=None,
+        description="A URI that identifies the specific occurrence of the error, typically the request URI.",
+        examples=["/users/create", "/auth/login"]
+    )


### PR DESCRIPTION
This PR introduces support for RFC 7807-compliant error responses and OpenAPI schema consistency improvements.

RFC 7807 Support
- Added RFC7807ResponseModel for problem+json structured error responses.
- Introduced response_format parameter (RESPONSE_MODEL, RESPONSE_DICTIONARY, RFC7807) to register_exception_handlers.
- Enhanced APIException with rfc7807_type and rfc7807_instance fields
- Implemented .to_rf7807_response() to return RFC 7807 error payloads


OpenAPI Null Field Injection
- Added include_null_data_field_in_openapi parameter.
- Automatically inserts "data": null into error response examples if missing
- Ensures consistent response shape and improves compatibility with typed clients (e.g., TypeScript, Kotlin).

New Example
- Created examples/fastapi_rfc7807_usage.py to demonstrate full usage in a FastAPI project.

Default behavior remains unchanged (RESPONSE_MODEL + include_null_data_field_in_openapi=True).
RFC 7807 mode can be enabled via:
`register_exception_handlers(app, response_format=ResponseFormat.RFC7807)`