### PR TITLE
feat(pyproject): migrate to PEP 621 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,64 +1,67 @@
-[tool.poetry]
+[project]
 name = "apiexception"
 version = "0.2.1"
 description = "Consistent JSON response formatting and exception & error handling for FastAPI applications"
-authors = ["Ahmet Kutay URAL <ahmetkutayural@gmail.com>"]
 readme = "README.md"
-license = "MIT"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Ahmet Kutay URAL", email = "ahmetkutayural@gmail.com" }]
 keywords = ["fastapi", "exception", "error-handling", "json-response"]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
-  "Environment :: Web Environment",
-  "Framework :: FastAPI",
-  "Intended Audience :: Developers",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-  "Topic :: Software Development :: Libraries :: Application Frameworks",
-  "Typing :: Typed",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Framework :: FastAPI",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Typing :: Typed",
+]
+dependencies = [
+    "click>=8.0.0",
+    "fastapi>=0.115.4",
+    "httpx>=0.27.0",
+    "pydantic>=2.0.0",
+    "typing-extensions>=4.0.0",
 ]
 
-packages = [
-  { include = "api_exception" }
-]
-
-[tool.poetry.urls]
-"Documentation" = "https://akutayural.github.io/APIException/"
-"Source" = "https://github.com/akutayural/APIException"
+[project.urls]
+Documentation = "https://akutayural.github.io/APIException/"
+Source = "https://github.com/akutayural/APIException"
 "Bug Tracker" = "https://github.com/akutayural/APIException/issues"
-"Changelog" = "https://github.com/akutayural/APIException/blob/main/docs/changelog.md"
+Changelog = "https://github.com/akutayural/APIException/blob/main/docs/changelog.md"
 
-[tool.poetry.dependencies]
-python = ">=3.9,<4.0"
-fastapi = ">=0.115.4"
-httpx = ">=0.27.0"
-pydantic = ">=2.0.0"
-click = ">=8.0.0"
-typing-extensions = ">=4.0.0"
-
-[tool.poetry.group.dev.dependencies]
-mkdocs-awesome-pages-plugin = ">=2.10.1"
-mkdocs-macros-plugin = ">=1.3.7"
-mkdocs-material = ">=9.6.16"
-ruff = "==0.12.5"
-setuptools = ">=80.9.0"
-uvicorn = ">=0.32.0"
-mypy = "^1.17.1"
-types-requests = "^2.32.4.20250809"
-types-click = "^7.1.8"
-
-[tool.poetry.scripts]
+[project.scripts]
 APIException-info = "api_exception.__main__:main"
+
+[dependency-groups]
+dev = [
+    "mkdocs-awesome-pages-plugin>=2.10.1",
+    "mkdocs-macros-plugin>=1.3.7",
+    "mkdocs-material>=9.6.16",
+    "ruff==0.12.5",
+    "setuptools>=80.9.0",
+    "uvicorn>=0.32.0",
+    "mypy>=1.17.1,<2.0.0",
+    "types-requests>=2.32.4.20250809,<3.0.0",
+    "types-click>=7.1.8,<8.0.0",
+]
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+packages = [
+    { include = "api_exception" }
+]
 
 [tool.setuptools.package-data]
 api_exception = ["py.typed"]


### PR DESCRIPTION
## Summary

- Updated project metadata to use `[project]` table.
- Moved dependencies, dev dependencies,  URLs, authors, and classifiers to PEP 621 format.
- Retained `[tool.poetry].packages` for backward compatibility.
- Poetry continues to work seamlessly.

Uv cannot work on the pyproject.toml configured for poetry. The Change simplifies compatibility with modern packaging tools. 


